### PR TITLE
Fix port 9000 not available through docker link

### DIFF
--- a/core-site.xml.template
+++ b/core-site.xml.template
@@ -1,6 +1,6 @@
   <configuration>
       <property>
           <name>fs.defaultFS</name>
-          <value>hdfs://HOSTNAME:9000</value>
+          <value>hdfs://0.0.0.0:9000</value>
       </property>
   </configuration>


### PR DESCRIPTION
With binding to the hostname the port was not available to other docker containers.
(also suggested here: [Cloudera](https://community.cloudera.com/t5/tkb/articleprintpage/tkb-id/CDHInstall@tkb/article-id/2) )
